### PR TITLE
Substituting fc-cache with fontconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In this repository you can find a bunch of fonts that I use as symbol fonts with
 * **Pomicons**: `./fonts/pomicons-regular.ttf`, for further informations and license see https://github.com/gabrielelana/pomicons
 
 ## How to install
-* (OSX) if you don't have fontcache installed, one way to get it is to run `brew install fc-cache`
+* (OSX) if you don't have fontcache installed, one way to get it is to run `brew install fontconfig`
 * copy all the fonts from `./build` directory to `~/.fonts` directory
 * run `fc-cache -fv ~/.fonts` to let freetype2 know of those fonts
 * customize the configuration file `./config/10-symbols.conf` replacing `PragmataPro` with the name of the font you want to use in the terminal (I will add more fonts in the future so that this step could be skippable)


### PR DESCRIPTION
fc-cache is not available anymore with brew. As highlighted in one of the listed issues the best solution is to use fontconfig