### PR TITLE
WIP: Add Source Code Pro to the list of substituted fonts

### DIFF
--- a/config/10-symbols.conf
+++ b/config/10-symbols.conf
@@ -22,6 +22,7 @@ to be looked into when a glyph is not found in a specic font
 <fontconfig>
   <alias>
     <family>PragmataPro</family>
+    <family>SourceCodePro</family>
     <prefer>
       <family>Pomodoro</family>
       <family>FontAwesome</family>


### PR DESCRIPTION
Hello,

I'm using Source Code Pro in my terminal and had some trouble in realizing that I had to change the name of the font in the config file since I used the Arch Package. I think Source Code Pro is a quite popular font for terminal output. Making it work by default will make it easier for a lot of people to use this font with PowerLevel9k for example.

I tested theses changes on ArchLinux running Linux kernel 4.16.11-1-ARCH. Everything seems to work properly despite of the presence of a conflicting font (provided by the ttf-ms-fonts package).

Thanks a lot for your work, keep it up !